### PR TITLE
fixed: attitude pitch is inverted

### DIFF
--- a/app/src/main/java/crazydude/com/telemetry/protocol/decoder/MAVLinkDataDecoder.kt
+++ b/app/src/main/java/crazydude/com/telemetry/protocol/decoder/MAVLinkDataDecoder.kt
@@ -86,7 +86,7 @@ class MAVLinkDataDecoder(listener: Listener) : DataDecoder(listener) {
                 val byteBuffer = ByteBuffer.wrap(data.rawData).order(ByteOrder.LITTLE_ENDIAN)
                 val time = byteBuffer.int
                 val roll = byteBuffer.float
-                val pitch = byteBuffer.float
+                val pitch = -byteBuffer.float
                 val yaw = byteBuffer.float
                 val rollSpeed = byteBuffer.float
                 val pitchSpeed = byteBuffer.float


### PR DESCRIPTION
Setup: inav mavlink + qczek lrs + HC-06 outputs mavlink
IS: attitude pitch is inverted:
with nose down, horizon line is moved down
SHOULD: with nose down, horizon line move up

As you can see in inav source code, mavlink protocol outputs inverted pitch:
https://github.com/iNavFlight/inav/blob/master/src/main/telemetry/mavlink.c

Compared to smartport protocol:
https://github.com/iNavFlight/inav/blob/master/src/main/telemetry/smartport.c