### PR TITLE
fixed: application gets frozen after orientation change

### DIFF
--- a/app/src/main/java/crazydude/com/telemetry/ui/MapsActivity.kt
+++ b/app/src/main/java/crazydude/com/telemetry/ui/MapsActivity.kt
@@ -397,7 +397,7 @@ class MapsActivity : AppCompatActivity(), DataDecoder.Listener {
                 }
 
                 override fun onDataReady(size: Int) {
-                    progressDialog.hide()
+                    progressDialog.dismiss()
                     seekBar.max = size
                     seekBar.visibility = View.VISIBLE
                     seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {


### PR DESCRIPTION
IS: In replay mode, application is frozen on orientation change

REPRODUCTION: 
1) click replay button
2) select any file
3) rotate phone
-> applicatoin is frozen

FIXED: progress dialog should be remove with dismiss() method, not hide() method.