### PR TITLE
implemented: do not show cell voltage if not available

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,8 +22,8 @@ android {
         applicationId "crazydude.com.telemetry"
         minSdkVersion 17
         targetSdkVersion 28
-        versionCode 27
-        versionName "1.7.1"
+        versionCode 28
+        versionName "1.8"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/crazydude/com/telemetry/ui/MapsActivity.kt
+++ b/app/src/main/java/crazydude/com/telemetry/ui/MapsActivity.kt
@@ -1042,7 +1042,10 @@ class MapsActivity : AppCompatActivity(), DataDecoder.Listener {
     }
 
     private fun updateVoltage() {
-        this.voltage.text = "$lastVBAT (${"%.2f".format(lastCellVoltage)}) V"
+        if ( lastCellVoltage > 0 )
+            this.voltage.text =  "$lastVBAT (${"%.2f".format(lastCellVoltage)}) V"
+        else
+            this.voltage.text = "$lastVBAT V"
     }
 
     override fun onDisconnected() {
@@ -1113,7 +1116,8 @@ class MapsActivity : AppCompatActivity(), DataDecoder.Listener {
             when (batteryUnits) {
                 "mAh", "mWh" -> {
                     this.fuel.text = "$fuel $batteryUnits"
-                    realFuel = ((1 - (4.2f - lastCellVoltage)).coerceIn(0f, 1f) * 100).toInt()
+                    if ( lastCellVoltage > 0)
+                        realFuel = ((1 - (4.2f - lastCellVoltage)).coerceIn(0f, 1f) * 100).toInt()
                 }
                 "Percentage" -> {
                     this.fuel.text = "$fuel%"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11955117/104850468-f83f5a80-58f7-11eb-8195-384e6d2ab033.png)

Cell voltage is not available with Mavlink protocol. There is not sence to show zero values.

Implemented: cell voltage is shown and used in reafuel caulation only if available.