### PR TITLE
fixed: incorrect speed value

### DIFF
--- a/app/src/main/java/crazydude/com/telemetry/ui/MapsActivity.kt
+++ b/app/src/main/java/crazydude/com/telemetry/ui/MapsActivity.kt
@@ -1082,7 +1082,7 @@ class MapsActivity : AppCompatActivity(), DataDecoder.Listener {
     }
 
     private fun updateSpeed(speed: Float) {
-        this.speed.text = "${KmhToMphConverter().convert(speed).roundToInt()} km/h"
+        this.speed.text = "${speed.roundToInt()} km/h"
     }
 
     override fun onGPSState(satellites: Int, gpsFix: Boolean) {


### PR DESCRIPTION
IS: Speed (km/h) value shown in Telemetry Viewer is lower then value in OSD.
Environment: Inav 2.6, mavlink.

Bug: looking at DataDecoder.onGSpeedData() inMavlinkDataDecoder and LTMDataDecoder, the speed values are in km/h.
Speed values are incorrectly converted from miles/h to km/h in MapsActivity.updateSpeed().

p.s You may want to double-check CrfsDataDecoder ( divisor is probably should be 10, not 100 as Crfs sends km/h * 10, see https://github.com/iNavFlight/inav/blob/master/src/main/telemetry/crsf.c ) and FrskyDataDecoder (I do not have idea where coefficient 27 is coming from. Values are knots, see https://github.com/iNavFlight/inav/blob/master/src/main/telemetry/frsky_d.c).

