### PR TITLE
Custom probing table to support STM32 Virtual COM Port

### DIFF
--- a/app/src/main/java/crazydude/com/telemetry/ui/MapsActivity.kt
+++ b/app/src/main/java/crazydude/com/telemetry/ui/MapsActivity.kt
@@ -29,6 +29,8 @@ import com.google.android.gms.maps.*
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.maps.android.SphericalUtil
+import com.hoho.android.usbserial.driver.CdcAcmSerialDriver
+import com.hoho.android.usbserial.driver.ProbeTable
 import com.hoho.android.usbserial.driver.UsbSerialPort
 import com.hoho.android.usbserial.driver.UsbSerialProber
 import com.nex3z.flowlayout.FlowLayout
@@ -45,7 +47,6 @@ import crazydude.com.telemetry.protocol.decoder.DataDecoder
 import crazydude.com.telemetry.protocol.pollers.LogPlayer
 import crazydude.com.telemetry.service.DataService
 import crazydude.com.telemetry.utils.DocumentLogFile
-import crazydude.com.telemetry.utils.FileLogger
 import crazydude.com.telemetry.utils.LogFile
 import crazydude.com.telemetry.utils.StandardLogFile
 import uk.co.deanwild.materialshowcaseview.MaterialShowcaseView
@@ -778,7 +779,11 @@ class MapsActivity : AppCompatActivity(), DataDecoder.Listener {
 
     private fun connectUSB() {
         val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
-        val drivers = UsbSerialProber.getDefaultProber().findAllDrivers(usbManager)
+
+        val customTable = UsbSerialProber.getDefaultProbeTable()
+        customTable.addProduct(0x0483, 0x5740, CdcAcmSerialDriver::class.java) // STM32 Virtual COM Port
+        val drivers = UsbSerialProber(customTable).findAllDrivers(usbManager)
+
         val driver = drivers.firstOrNull()
         if (driver == null) {
             Toast.makeText(this, "No valid usb driver has been found", Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
This PR adds support for the USB Serial driver automatically recognizing STM32F4-based devices that use the default STM Virtual COM Port VID and PID.

Note that the upstream usb-serial-for-android project is no longer accepting PRs for new USB-CDC devices, preferring instead for applications themselves to build out custom probing tables for devices they would like to work with: https://github.com/mik3y/usb-serial-for-android/pull/289

This feature will specifically be useful for an upcoming feature in OpenTX that I'm working on - adding telemetry output via USB serial.  