### PR TITLE
minor bugfix in mavlink data decoder

### DIFF
--- a/app/src/main/java/crazydude/com/telemetry/protocol/decoder/MAVLinkDataDecoder.kt
+++ b/app/src/main/java/crazydude/com/telemetry/protocol/decoder/MAVLinkDataDecoder.kt
@@ -212,7 +212,7 @@ class MAVLinkDataDecoder(listener: Listener) : DataDecoder(listener) {
         if (newLatitude && newLongitude) {
             listener.onGPSData(latitude, longitude)
 
-            if (originLatitude > 0 && originLatitude > 0 && latitude > 0 && longitude > 0) {
+            if (originLatitude > 0 && originLongitude > 0 && latitude > 0 && longitude > 0) {
 
                 val distance = SphericalUtil.computeDistanceBetween(
                     LatLng(


### PR DESCRIPTION
originLatitude is checked two times instead of originLongitude




