### PR TITLE
Fixed app crash when replaying a logfile and changing phone orientation

### DIFF
--- a/app/src/main/java/crazydude/com/telemetry/ui/MapsActivity.kt
+++ b/app/src/main/java/crazydude/com/telemetry/ui/MapsActivity.kt
@@ -511,7 +511,7 @@ class MapsActivity : AppCompatActivity(), DataDecoder.Listener {
             if (shouldUseStorageAPI()) {
                 replayFileString = it.uri.toString()
             } else {
-                replayFileString = it.name
+                replayFileString = it.name + ".log"
             }
 
             val logPlayer =


### PR DESCRIPTION
When replaying a logfile (using the FileAPI) the App crashes when you rotate the Phone.
The App reloads in the new orientation and tries to load the logfile using the replayFileString.
But if the storageAPI isnt used the replayFileString is set to the logfile NAME, without the extension (".log") which causes the App to crash when loading the file (FileNotFoundException: No such file or directory).

![TelemetryViewer_RotationError](https://user-images.githubusercontent.com/20909995/119259400-78d7d580-bbce-11eb-9f9b-e2567269357b.PNG)
![TelemetryViewer_RotationError_Fix](https://user-images.githubusercontent.com/20909995/119259401-79706c00-bbce-11eb-89d7-a4b57885741e.PNG)
