### PR TITLE
fixed sensor adapter

### DIFF
--- a/app/src/main/java/crazydude/com/telemetry/ui/adapters/SensorsAdapter.kt
+++ b/app/src/main/java/crazydude/com/telemetry/ui/adapters/SensorsAdapter.kt
@@ -56,10 +56,14 @@ class SensorsAdapter(
         if (getItemViewType(position) == 0) {
             val sensor = data[position] as SensorsActivity.Sensor
             holder.switch!!.text = sensor.name
-            holder.switch.isChecked = sensor.isShown
+
+            //sensor views can be recycled
+            //it is important to set listener first, set value second
+            //otherwise old listener will be called
             holder.switch.setOnCheckedChangeListener { compoundButton, value ->
                 sensor.isShown = value
             }
+            holder.switch.isChecked = sensor.isShown
             holder.settingsButton?.setOnClickListener {
                 sensorsAdapterListener.onSettingsClick(position)
             }


### PR DESCRIPTION
This pr fixes the following bug:
In sensor configuration dialog, where some sensors are enabled and some are disabled, on small landscape screen, scroll the list up and down. See some checkboxes change value without user input.
Reason: 'item' views are recycled by list component. Assigning "checked" value to used item calls old callback.
Resolution: install new callback first, assign value after.