### PR TITLE
Option to show RF mode and LQ for Crossfire

### DIFF
--- a/app/src/main/java/crazydude/com/telemetry/manager/PreferenceManager.kt
+++ b/app/src/main/java/crazydude/com/telemetry/manager/PreferenceManager.kt
@@ -137,6 +137,10 @@ class PreferenceManager(context: Context) {
             .apply()
     }
 
+    fun useCrsfLq() : Boolean {
+        return sharedPreferences.getBoolean("use_crsf_lq", false)
+    }
+
     data class SensorSetting(
         val name: String,
         val index: Int,

--- a/app/src/main/java/crazydude/com/telemetry/protocol/CrsfProtocol.kt
+++ b/app/src/main/java/crazydude/com/telemetry/protocol/CrsfProtocol.kt
@@ -197,6 +197,20 @@ class CrsfProtocol : Protocol {
                                 inputData
                             )
                         )
+                        dataDecoder.decodeData(
+                            Protocol.Companion.TelemetryData(
+                                CRSF_LQ,
+                                uplinkLQ,
+                                inputData
+                            )
+                        )
+                        dataDecoder.decodeData(
+                            Protocol.Companion.TelemetryData(
+                                CRSF_RF,
+                                rfMode,
+                                inputData
+                            )
+                        )
                     }
                 }
                 FLIGHT_MODE.toByte() -> {

--- a/app/src/main/java/crazydude/com/telemetry/protocol/Protocol.kt
+++ b/app/src/main/java/crazydude/com/telemetry/protocol/Protocol.kt
@@ -62,6 +62,8 @@ abstract class Protocol(val dataDecoder: DataDecoder) {
         const val ARDU_BATT_2 = 52
         const val ARDU_BATT_1 = 53
         const val ARDU_PARAM = 54
+        const val CRSF_LQ = 55
+        const val CRSF_RF = 56
 
         const val RC_CHANNEL_0 = 100
         const val RC_CHANNEL_1 = 101

--- a/app/src/main/java/crazydude/com/telemetry/protocol/TelemetryModel.kt
+++ b/app/src/main/java/crazydude/com/telemetry/protocol/TelemetryModel.kt
@@ -25,7 +25,9 @@ data class TelemetryModel(
     var flightMode1: DataDecoder.Companion.FlyMode? = null,
     var flightMode2: DataDecoder.Companion.FlyMode? = null,
     var airSpeed: Float = 0f,
-    var rssi: Int = -1) {
+    var rssi: Int = -1,
+    var crsfLq: Int = -1,
+    var crsfRf: Int = -1) {
 
     fun decodeCurrentModes() : String {
         var mode = if (armed) "Armed" else "Disarmed"

--- a/app/src/main/java/crazydude/com/telemetry/protocol/decoder/CrsfDataDecoder.kt
+++ b/app/src/main/java/crazydude/com/telemetry/protocol/decoder/CrsfDataDecoder.kt
@@ -55,6 +55,12 @@ class CrsfDataDecoder(listener: Listener) : DataDecoder(listener) {
             Protocol.RSSI -> {
                 listener.onRSSIData((data.data - MIN_RSSI) * 100 / (MAX_RSSI - MIN_RSSI))
             }
+            Protocol.CRSF_LQ -> {
+                listener.onCrsfLqData(data.data)
+            }
+            Protocol.CRSF_RF -> {
+                listener.onCrsfRfData(data.data)
+            }
             Protocol.FUEL -> {
                 listener.onFuelData(data.data)
             }

--- a/app/src/main/java/crazydude/com/telemetry/protocol/decoder/DataDecoder.kt
+++ b/app/src/main/java/crazydude/com/telemetry/protocol/decoder/DataDecoder.kt
@@ -70,6 +70,12 @@ abstract class DataDecoder(protected val listener: Listener) {
             override fun onRSSIData(rssi: Int) {
             }
 
+            override fun onCrsfLqData(lq: Int) {
+            }
+
+            override fun onCrsfRfData(rf: Int) {
+            }
+
             override fun onDisconnected() {
             }
 
@@ -127,6 +133,8 @@ abstract class DataDecoder(protected val listener: Listener) {
         fun onCurrentData(current: Float)
         fun onHeadingData(heading: Float)
         fun onRSSIData(rssi: Int) //-1 - unknown/invalid, or device-dependent value
+        fun onCrsfLqData(lq: Int)
+        fun onCrsfRfData(rf: Int)
         fun onDisconnected()
         fun onGPSState(satellites: Int, gpsFix: Boolean)
         fun onVSpeedData(vspeed: Float)

--- a/app/src/main/java/crazydude/com/telemetry/protocol/pollers/LogPlayer.kt
+++ b/app/src/main/java/crazydude/com/telemetry/protocol/pollers/LogPlayer.kt
@@ -218,6 +218,14 @@ class LogPlayer(val originalListener: DataDecoder.Listener) : DataDecoder.Listen
         originalListener.onRSSIData(rssi)
     }
 
+    override fun onCrsfLqData(lq: Int) {
+        originalListener.onCrsfLqData(lq)
+    }
+
+    override fun onCrsfRfData(rf: Int) {
+        originalListener.onCrsfRfData(rf)
+    }
+
     override fun onGPSData(list: List<Position>, addToEnd: Boolean) {
 
     }

--- a/app/src/main/java/crazydude/com/telemetry/service/DataService.kt
+++ b/app/src/main/java/crazydude/com/telemetry/service/DataService.kt
@@ -287,6 +287,14 @@ class DataService : Service(), DataDecoder.Listener {
         telemetryModel.rssi = rssi
     }
 
+    override fun onCrsfLqData(lq: Int) {
+        telemetryModel.crsfLq = lq
+    }
+
+    override fun onCrsfRfData(rf: Int) {
+        telemetryModel.crsfRf = rf
+    }
+
     override fun onDisconnected() {
         dataPoller = null
         telemetryModel = TelemetryModel()

--- a/app/src/main/java/crazydude/com/telemetry/ui/MapsActivity.kt
+++ b/app/src/main/java/crazydude/com/telemetry/ui/MapsActivity.kt
@@ -16,7 +16,6 @@ import android.os.*
 import android.provider.DocumentsContract
 import android.text.Html
 import android.text.method.LinkMovementMethod
-import android.util.Log
 import android.view.View
 import android.widget.*
 import androidx.activity.viewModels
@@ -31,7 +30,6 @@ import com.google.android.gms.maps.*
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.maps.android.SphericalUtil
 import com.hoho.android.usbserial.driver.CdcAcmSerialDriver
-import com.hoho.android.usbserial.driver.ProbeTable
 import com.hoho.android.usbserial.driver.UsbSerialPort
 import com.hoho.android.usbserial.driver.UsbSerialProber
 import crazydude.com.telemetry.R
@@ -1018,9 +1016,19 @@ class MapsActivity : AppCompatActivity() {
     }
 
     private fun updateRSSI() {
-        var rssi = binding.telemetry?.value?.rssi
-        this.binding.topLayout.rssi.text = if (rssi == -1) "-" else rssi.toString()
-        this.setRSSIIcon(rssi?:-1);
+        var iconValue = 0;
+        var text = ""
+        var lq = binding.telemetry?.value?.crsfLq
+        var rf = binding.telemetry?.value?.crsfRf
+        if (preferenceManager.useCrsfLq() && lq != -1 && rf != -1 ) {
+            iconValue = lq!!;
+            text  = rf.toString() + ":" + lq.toString()
+        } else {
+            iconValue = binding.telemetry?.value?.rssi!!
+            text = if (iconValue == -1) "-" else iconValue.toString()
+        }
+        this.binding.topLayout.rssi.text = text
+        this.setRSSIIcon(iconValue ?: -1);
     }
 
     private fun checkSendDataDialogShown() {

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -13,6 +13,7 @@
             android:key="log_folder"
             android:title="Logs directory" />
 
+
     <com.jaredrummler.android.colorpicker.ColorPreferenceCompat
             android:defaultValue="@color/colorPlane"
             android:key="plane_color"
@@ -99,7 +100,7 @@
             android:title="Crossfire RF/LQ"
             android:key="use_crsf_lq"
             android:defaultValue="false"
-            android:summary="Show RF/LQ insted of RSSI for Crossfie"
+            android:summary="Show RF/LQ instead of RSSI for Crossfire"
             />
 
     </PreferenceCategory>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -95,6 +95,12 @@
                 android:key="show_artificial_horizon"
                 android:summary="Shows attitude. Please set frsky_pitch_roll = ON in CLI for Inav 2.0.+."
                 android:title="Show artificial horizon view" />
+        <SwitchPreference
+            android:title="Crossfire RF/LQ"
+            android:key="use_crsf_lq"
+            android:defaultValue="false"
+            android:summary="Show RF/LQ insted of RSSI for Crossfie"
+            />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
RSSI is pretty useless for Crossfire, add option to show RF mode and LQ instead of RSSI.

Format is "RF_Mode:LQ"
![IMG_20211227_125857](https://user-images.githubusercontent.com/1850465/147469843-eaccf54c-c69c-4188-906b-2a274f9b0c18.jpg)
"