### PR TITLE
Show notification only if adapter is connected

### DIFF
--- a/app/src/main/java/crazydude/com/telemetry/service/DataService.kt
+++ b/app/src/main/java/crazydude/com/telemetry/service/DataService.kt
@@ -1,10 +1,7 @@
 package crazydude.com.telemetry.service
 
 import android.annotation.TargetApi
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.app.PendingIntent
-import android.app.Service
+import android.app.*
 import android.bluetooth.BluetoothDevice
 import android.content.Context
 import android.content.Intent
@@ -49,6 +46,7 @@ class DataService : Service(), DataDecoder.Listener {
     private var telemetryModel = TelemetryModel()
     private val mutableTelemetryLiveData = MutableLiveData(telemetryModel)
     private var mutableConnectionStateLiveData = MutableLiveData(ConnectionState.DISCONNECTED)
+    private var notification: Notification? = null
 
     val telemetryLiveData = mutableTelemetryLiveData as LiveData<TelemetryModel>
     val connectionStateLiveData = mutableConnectionStateLiveData as LiveData<ConnectionState>
@@ -69,8 +67,8 @@ class DataService : Service(), DataDecoder.Listener {
         }
 
 
-        val notification = NotificationCompat.Builder(this, "bt_channel")
-            .setContentText("Telemetry service is running. To stop - disconnect and close the app")
+        notification = NotificationCompat.Builder(this, "bt_channel")
+            .setContentText("Telemetry service is running. To stop - disconnect")
             .setContentTitle("Telemetry service is running")
             .setContentIntent(
                 PendingIntent.getActivity(
@@ -82,7 +80,6 @@ class DataService : Service(), DataDecoder.Listener {
             )
             .setSmallIcon(R.drawable.ic_launcher_foreground)
             .build()
-        startForeground(1, notification)
     }
 
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
@@ -174,6 +171,7 @@ class DataService : Service(), DataDecoder.Listener {
         if (preferenceManager.isSendDataEnabled()) {
             createSession()
         }
+        startForeground(1, notification)
     }
 
 
@@ -292,6 +290,7 @@ class DataService : Service(), DataDecoder.Listener {
         telemetryModel = TelemetryModel()
         mutableTelemetryLiveData.postValue(telemetryModel)
         mutableConnectionStateLiveData.postValue(ConnectionState.DISCONNECTED)
+        stopForeground(true)
         Toast.makeText(this, "Disconnected", Toast.LENGTH_LONG).show()
     }
 


### PR DESCRIPTION
I think there is no reason to show the notification when the app is in background and no connection is active. The only way to get rid of it, is to force close the app or wait until it's closed by the system, for me its really annoying.